### PR TITLE
fix: replace double quotes with single quote inside f strings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#043523",
+        "titleBar.activeBackground": "#054A31",
+        "titleBar.activeForeground": "#EBFEF7"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#043523",
-        "titleBar.activeBackground": "#054A31",
-        "titleBar.activeForeground": "#EBFEF7"
-    }
-}

--- a/src/py_positron/startproj.py
+++ b/src/py_positron/startproj.py
@@ -23,7 +23,7 @@ def get_venv_positron_version(python_executable):
         # Run a command to get the version from the target environment
         cmd = [python_executable, "-c", "import py_positron; print(py_positron.__version__)"]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-        
+
         if result.returncode == 0:
             return result.stdout.strip()
         else:
@@ -52,11 +52,11 @@ def check_and_warn_version_mismatch(python_executable):
     current_version = get_current_positron_version()
     if not current_version:
         return  # Can't check if we don't know current version
-    
+
     venv_version = get_venv_positron_version(python_executable)
     if not venv_version:
         return  # Can't check if we can't get venv version
-    
+
     if compare_versions(current_version, venv_version):
         warn_version_mismatch(current_version, venv_version)
 
@@ -65,7 +65,7 @@ def check_and_warn_version_mismatch_linux(venv_path):
     current_version = get_current_positron_version()
     if not current_version:
         return  # Can't check if we don't know current version
-    
+
     python_executable = os.path.join(venv_path, "bin", "python3")
     if os.path.exists(python_executable):
         venv_version = get_venv_positron_version(python_executable)
@@ -101,7 +101,7 @@ def start(argv):
                 if os.path.exists(config.get("winvenv_executable","")) and config.get("winvenv_executable","") != "":
                     # Check for version mismatch before running
                     check_and_warn_version_mismatch(config["winvenv_executable"])
-                    cmd = ["powershell","-NoProfile","-ExecutionPolicy", "Bypass","-Command", f"& \'{absolute}\' \'{config["entry_file"]}\' \'{os.getcwd()}\' \'{config["winvenv_executable"]}\'"]
+                    cmd = ["powershell","-NoProfile","-ExecutionPolicy", "Bypass","-Command", f"& '{absolute}' '{config['entry_file']}' '{os.getcwd()}' '{config['winvenv_executable']}'"]
                     result = subprocess.run(cmd,check=True)
                     if result.returncode != 0:
                         print("Error:", result.stderr, file=sys.stderr)
@@ -110,7 +110,7 @@ def start(argv):
                 else:
                     print("\x1b[0;93;49m[WARN]Running without venv, as this project does not contain a windows venv, but has a linux venv.\x1b[0m")
             # Use the executable from command line argument instead of config
-            cmd = ["powershell","-NoProfile","-ExecutionPolicy", "Bypass","-Command", f"& '{absolute}' \'{config["entry_file"]}\' \'{os.getcwd()}\' \'{args.executable}\'"]
+            cmd = ["powershell","-NoProfile","-ExecutionPolicy", "Bypass","-Command", f"& '{absolute}' '{config['entry_file']}' '{os.getcwd()}' '{args.executable}'"]
             result = subprocess.run(cmd,check=True)
             if result.returncode != 0:
                 print("Error:", result.stderr, file=sys.stderr)
@@ -132,7 +132,7 @@ def start(argv):
             ps1_path = Path(__file__).parent / "python_executor.ps1"
             absolute = ps1_path.resolve()
             # Use the executable from command line argument instead of config
-            cmd = ["powershell","-NoProfile","-ExecutionPolicy", "Bypass","-Command", f"& '{absolute}' \'{config["entry_file"]}\' \'{os.getcwd()}\' \'{args.executable}\'"]
+            cmd = ["powershell","-NoProfile","-ExecutionPolicy", "Bypass","-Command", f"& '{absolute}' '{config['entry_file']}' '{os.getcwd()}' '{args.executable}'"]
             result = subprocess.run(cmd,check=True)
             if result.returncode != 0:
                 print("Error:", result.stderr, file=sys.stderr)


### PR DESCRIPTION
## Description
Error on `positron start` due to double-quotes inside a double-quoted f string.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe): 

## Checklist
<!--Replace [ ] with [x] to check a checkbox.-->
- [ ] My code follows the style guidelines of this project.
- [x] I tested the code.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated documentation as needed.
- [x] My changes generate no new warnings/errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally.

## Additional context

### Fix this error I found, at least in my Windows boot
![Screenshot 2025-06-26 230219](https://github.com/user-attachments/assets/dc588866-6119-4d8a-ac66-6c24a1bcb68a)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting and consistency of command strings for better readability.
  * Removed unnecessary trailing whitespace in several functions.

* **Chores**
  * Added a Visual Studio Code workspace settings file with customized color themes for the editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->